### PR TITLE
More embedable approach for the Dockerfile

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -62,5 +62,6 @@ WORKDIR /app
 COPY --from=tools /app/ /app/
 RUN pip install --no-deps -e .
 COPY --from=front-builder /app/build /opt/drealcorsereports/static/admin/build
-
 ENV PROXY_PREFIX=
+EXPOSE 8080
+CMD pserve c2c://${INI_FILE}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,6 @@ services:
       - PGOPTIONS
       - INI_FILE
       - PROXY_PREFIX
-    command: 'pserve c2c://${INI_FILE}'
     ports:
       - ${DOCKER_PORT}:8080
 


### PR DESCRIPTION
The Dockerfile had no `CMD` and no `EXPOSE` default. This default to make the embed of the image more easy (less stuff to write in docker-compose)