### PR TITLE
Register pyramid_tm default_commit_veto

### DIFF
--- a/app/drealcorsereports/__init__.py
+++ b/app/drealcorsereports/__init__.py
@@ -5,6 +5,8 @@ from pyramid.config import Configurator
 
 def main(global_config, **settings):
     del global_config
+    settings['tm.commit_veto'] = 'pyramid_tm.default_commit_veto'
+
     config = Configurator(settings=settings)
 
     config.include("drealcorsereports.models.includeme")


### PR DESCRIPTION
Fix https://jira.camptocamp.com/browse/GSDREALCOR-56
I did not find easy way to demonstrate it in tests as currently test_app does not use the same transaction manager as the dbsession.
Changing this might require a big refactorisation of tests.