### PR TITLE
fields names can't be changed, report name can be edited

### DIFF
--- a/app/drealcorsereports/static/admin/package-lock.json
+++ b/app/drealcorsereports/static/admin/package-lock.json
@@ -3936,9 +3936,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001173",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001173.tgz",
-      "integrity": "sha512-R3aqmjrICdGCTAnSXtNyvWYMK3YtV5jwudbq0T7nN9k4kmE4CBuwPqyJ+KBzepSTh0huivV2gLbSMEzTTmfeYw=="
+      "version": "1.0.30001239",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001239.tgz",
+      "integrity": "sha512-cyBkXJDMeI4wthy8xJ2FvDU6+0dtcZSJW3voUF8+e9f1bBeuvyZfc3PNbkOETyhbR+dGCPzn9E7MA3iwzusOhQ=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -12658,7 +12658,6 @@
         "react-app-polyfill": "^2.0.0",
         "react-dev-utils": "^11.0.1",
         "react-refresh": "^0.8.3",
-        "react-tagsinput": "3.19.0",
         "resolve": "1.18.1",
         "resolve-url-loader": "^3.1.2",
         "sass-loader": "8.0.2",

--- a/app/drealcorsereports/static/admin/package.json
+++ b/app/drealcorsereports/static/admin/package.json
@@ -17,6 +17,7 @@
     "react-icons": "^4.2.0",
     "react-scripts": "4.0.1",
     "react-select": "^4.3.0",
+    "react-tagsinput": "^3.19.0",
     "web-vitals": "^0.2.4"
   },
   "scripts": {


### PR DESCRIPTION
**edit** : report name can be edited, readOnly on field removed

- report and field names are created when the report is first created then can't be changed
-  UI :

report creation :
![drealadminfront_reportcreation](https://user-images.githubusercontent.com/78360657/120610105-2068c980-c453-11eb-98b1-ab9e2a11198f.png)

report edition :
![drealadminfront_reportedition](https://user-images.githubusercontent.com/78360657/120610107-21016000-c453-11eb-9de5-c66304856e49.png)
